### PR TITLE
[hotfix]express.static에 상수 값 잘못 들어가던 것 변경

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -13,7 +13,7 @@ app.set('port', PORT);
 Loader({ server, app });
 
 app.use('/api', apiRouter);
-app.use(FILE_PUBLIC_URL, express.static(FILE_PUBLIC_URL));
+app.use(FILE_PUBLIC_URL, express.static(FILE_PUBLIC_URL.slice(1)));
 
 function onListening(): void {
   const addr = server.address();


### PR DESCRIPTION
# [Deprecated]

* Object Storage 로 변경하여 필요 없어진 HotFix 입니다.