### PR TITLE
[Hotfix] Mark를 화면에 출력하는 Debounce 로직을 Throttle로 변경

### DIFF
--- a/client/src/socket/mark.ts
+++ b/client/src/socket/mark.ts
@@ -5,20 +5,22 @@ const mark = (socket: Socket) => (closure: any) => {
   const { setMarks, removeQuestionMark } = closure;
   let count = 0;
   let marks = {};
-  let frame;
+  let timeout;
 
   socket.on(MARK_BROADCAST, ({ x, y }) => {
     marks[++count] = { x, y };
-    if (frame) cancelAnimationFrame(frame);
-    frame = requestAnimationFrame(() => {
-      Object.keys(marks).forEach((cnt) => {
-        removeQuestionMark(cnt);
-      });
-      setMarks((prev) => {
-        return { ...prev, ...marks };
-      });
-      marks = {};
-    });
+    if (!timeout) {
+      timeout = setTimeout(() => {
+        timeout = null;
+        Object.keys(marks).forEach((cnt) => {
+          removeQuestionMark(cnt);
+        });
+        setMarks((prev) => {
+          return { ...prev, ...marks };
+        });
+        marks = {};
+      }, 100);
+    }
   });
 
   const addQuestionMark = (position) => {


### PR DESCRIPTION
### WorkList

- [x] 기존 디바운스 로직이 오토마우스의 1ms를 대처하는 것에 적절하지 않다고 생각하여 요청이 들어오고 100ms동안 기다렸다가 화면에 출력하는 쓰로틀 방식으로 변경

### Issue

- 기존 방식이 1ms마다 들어오는 요청이 있다면 무한히 대기하겠다는 생각이 들었습니다.
- 그래서 아예 100ms마다 화면에 출력할 수 있도록 로직을 쓰로틀 방식으로 변경하였습니다.
- 혹시 문제가 되는 부분이나, 이렇게 바꿨으면 좋겠다 싶은 부분이 있으면 댓글로 달아주세요!

### Description

네.. 코드를 다시 보다보니 뭔가 아쉬운 부분이 있어서 고치고 싶었습니다..
디바운스와 쓰로틀에 대해 다시 복습할 수 있었던 좋은 시간이었네요.
